### PR TITLE
Updates for initial Hackage release of OChan

### DIFF
--- a/ochan/CHANGELOG.md
+++ b/ochan/CHANGELOG.md
@@ -1,0 +1,4 @@
+# CHANGELOG
+
+## 0.1.0
+   - Initial release

--- a/ochan/README.md
+++ b/ochan/README.md
@@ -1,3 +1,3 @@
-** OChan
-*** Intro
+# OChan
+
 Channels in the Ownership Monad.

--- a/ochan/ochan.cabal
+++ b/ochan/ochan.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f5370b3ec209d8f1ae55fc60977c67521178ad0459ef54f0d8e6372c77d2deaf
+-- hash: 517a933855fd57fbd0985a94fb807ee9723640e29036e50d295a617945a1a669
 
 name:           ochan
-version:        0.1.0.0
+version:        0.1.0
 synopsis:       Owned channels in the Ownership Monad
 description:    Resource tracking channels that use the rules enforced in the Ownership Monad.
 category:       Concurrency
@@ -20,7 +20,8 @@ license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
 extra-source-files:
-    README.org
+    README.md
+    CHANGELOG.md
 
 source-repository head
   type: git
@@ -35,7 +36,7 @@ library
     , base >=4.8 && <5
     , bytestring
     , mtl ==2.2.1
-    , oref
+    , oref >=0.0.3
     , text
     , transformers
   exposed-modules:
@@ -56,7 +57,7 @@ test-suite test
     , base >=4.8 && <5
     , bytestring
     , mtl ==2.2.1
-    , oref
+    , oref >=0.0.3
     , text
     , transformers
   other-modules:

--- a/ochan/package.yaml
+++ b/ochan/package.yaml
@@ -1,5 +1,5 @@
 name: ochan
-version: '0.1.0.0'
+version: '0.1.0'
 synopsis: Owned channels in the Ownership Monad
 description: Resource tracking channels that use the rules enforced in the Ownership Monad.
 category: Concurrency
@@ -9,11 +9,12 @@ copyright: 2017 Mike McGirr
 license: BSD3
 github: lambda-land/OwnershipMonad
 extra-source-files:
-  - README.org
+  - README.md
+  - CHANGELOG.md
 
 dependencies:
   - base >=4.8 && <5
-  - oref
+  - oref >= 0.0.3
   - mtl == 2.2.1
   - transformers
   # for the tests

--- a/ochan/shell.nix
+++ b/ochan/shell.nix
@@ -1,0 +1,9 @@
+with import (fetchTarball https://github.com/NixOS/nixpkgs/archive/18.03.tar.gz) {};
+let ghc = haskell.compiler.ghc802;
+in haskell.lib.buildStackProject {
+    inherit ghc;
+    name = "oref";
+    buildInputs = [ zlib unzip ];
+    LANG = "en_US.UTF-8";
+    TMPDIR = "/tmp";
+}

--- a/ochan/stack.yaml
+++ b/ochan/stack.yaml
@@ -37,11 +37,12 @@ resolver: lts-8.23
 # will not be run. This is useful for tweaking upstream packages.
 packages:
 - .
-- ../oref
+# - ../oref
+# For development
 
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps: [ oref-0.0.3 ]
 
 # Override default flag values for local packages and extra-deps
 flags: {}
@@ -67,6 +68,6 @@ extra-package-dbs: []
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
 
-# nix:
-#   enable: true
-#   shell-file: shell.nix
+nix:
+  enable: true
+  shell-file: shell.nix


### PR DESCRIPTION
- Switch ochan to use Hackage release of oref-0.0.3. 
- Other minor changes (add a shell.nix for building on NixOS)